### PR TITLE
Update and refactor setup.sh

### DIFF
--- a/code2nl/setup.sh
+++ b/code2nl/setup.sh
@@ -1,7 +1,7 @@
 # This is the basic steps based on CodeBERT, using the custom CodeBERT dataset.
 
 # Again incase you forgot to activate the venv
-. ../venv/bind/activate
+. ../venv/bin/activate
 
 pip3 install gdown
 mkdir ../data ../data/code2nl


### PR DESCRIPTION
in the first line to activate virtual environment, it was mentioned ```bind``` : 

```

# Again incase you forgot to activate the venv
. ../venv/bind/activate
```

I think it should be ```bin``` instead to activate virtual env : 


```

# Again incase you forgot to activate the venv
. ../venv/bin/activate

```